### PR TITLE
fixed bug where installing would overwrite all other extension's settings

### DIFF
--- a/vz_bad_behavior/ext.vz_bad_behavior.php
+++ b/vz_bad_behavior/ext.vz_bad_behavior.php
@@ -84,7 +84,7 @@ class Vz_bad_behavior_ext {
         
         // Use default settings
         $this->default_settings['log_table'] = $this->EE->db->dbprefix.'bad_behavior';
-    	$this->EE->db->update('extensions', array('settings' => serialize($this->default_settings)));
+    	$this->EE->db->update('extensions', array('settings' => serialize($this->default_settings)), array('class' => __CLASS__));
 	}
 
 	/**


### PR DESCRIPTION
kind of a nasty bug. this would write bad_behavior's default settings to every row in the exp_extensions table, rather than to just its own row.
